### PR TITLE
CI: Add CI/CD workflow

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy on GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: npm install, npm run build
+      run: |
+        npm install
+        npm build:production
+    - name: push to gh-pages
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.GH_PAGES_ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./dist

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "start": "NODE_PRESERVE_SYMLINKS=1 react-static start",
     "build": "NODE_PRESERVE_SYMLINKS=1 react-static build",
+    "build:production": "NODE_ENV=production SITE_ROOT=https://aragon.one/ react-static build && echo 'aragon.one' > dist/CNAME",
     "optimize-svg": "find ./src -name '*.svg' -exec svgo --config '{ \"plugins\": [ { \"removeDesc\": {\"removeAny\": true}, \"removeTitle\": true } ] }' {} \\;",
     "generate-favicon": "icon-gen -i favicon.png -o public -r",
-    "deploy": "NODE_ENV=production SITE_ROOT=https://aragon.one/ npm run build && echo 'aragon.one' > dist/CNAME && gh-pages -d dist"
+    "deploy": "npm run build:production && gh-pages -d dist"
   },
   "dependencies": {
     "@aragon/ui": "^0.32.0",


### PR DESCRIPTION
Adds a CI/CD workflow for publishing on push to master. For this to work, we need to complete a few things:

- [x] Add `build:production` command
- [x] Add secret keys for deployment cc @sohkai